### PR TITLE
Add biometric authentication to login

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,4 +73,7 @@ dependencies {
 
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.retrofit2:converter-gson:2.11.0")
+
+    //biometric
+    implementation("androidx.biometric:biometric:1.1.0")
 }

--- a/app/src/main/java/com/univalle/grupocinco/dogapp/view/LoginActivity.kt
+++ b/app/src/main/java/com/univalle/grupocinco/dogapp/view/LoginActivity.kt
@@ -6,6 +6,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import com.univalle.grupocinco.dogapp.R
 import com.univalle.grupocinco.dogapp.databinding.ActivityLoginBinding
+import androidx.biometric.BiometricPrompt
+import androidx.core.content.ContextCompat
+import java.util.concurrent.Executor
 
 class LoginActivity : AppCompatActivity() {
 
@@ -16,8 +19,33 @@ class LoginActivity : AppCompatActivity() {
         binding = DataBindingUtil.setContentView(this, R.layout.activity_login)
 
         binding.animationView.setOnClickListener {
-            navigateToMain()
+            userAuth()
         }
+    }
+
+    private fun userAuth(){
+        val executor: Executor = ContextCompat.getMainExecutor(this)
+        val biometricPrompt = BiometricPrompt(this, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationError(errorCode: Int, errorString: CharSequence) {
+                super.onAuthenticationError(errorCode, errorString)
+            }
+
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                super.onAuthenticationSucceeded(result)
+                navigateToMain()
+            }
+
+            override fun onAuthenticationFailed() {
+                super.onAuthenticationFailed()
+            }
+        })
+
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle("Autenticación de huella digital").setSubtitle("Ingrese su huella digital")
+            .setNegativeButtonText("Cancelar")
+            .build()
+
+        biometricPrompt.authenticate(promptInfo)
     }
 
     private fun navigateToMain() {


### PR DESCRIPTION
Implement biometric authentication using BiometricPrompt in the LoginActivity.
- Add the androidx.biometric:biometric dependency.
- Configure a BiometricPrompt instance with an AuthenticationCallback to handle success and failure.
- On successful authentication, navigate to the main activity.
- Trigger biometric authentication when the animation view is clicked.